### PR TITLE
Maintain the current model and thinking level after handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ When your conversation gets long or you want to branch off to a focused task, yo
 Optional flags (can be combined):
 - `-mode <name>` — start the new session in a named mode (e.g. `rush`, `smart`, `deep`)
 - `-model <provider/id>` — start the new session with a specific model (e.g. `anthropic/claude-haiku-4-5`)
+Without these flags, `/handoff` keeps the current model and thinking level in the new session.
 
 The handoff summary is always generated with the *current* session's model before switching.
 

--- a/extensions/handoff.ts
+++ b/extensions/handoff.ts
@@ -28,9 +28,16 @@ import { loadModeSpec } from "./lib/mode-utils.js";
 // When cmdCtx.newSession() replaces the session (0.65+), the old extension
 // instance is disposed and a new one is loaded. globalThis survives the
 // replacement, so we use a process-global symbol to pass the handoff prompt
-// from the old instance to the new one's session_start handler.
+// plus any default model/thinking restore data from the old instance to the
+// new one's session_start handler.
+type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
+type HandoffSelection = {
+	provider: string;
+	modelId: string;
+	thinkingLevel: ThinkingLevel;
+};
 const HANDOFF_GLOBAL_KEY = Symbol.for("pi-amplike-handoff-pending");
-type PendingHandoffGlobal = { prompt: string; options?: HandoffOptions } | null;
+type PendingHandoffGlobal = { prompt: string; options?: HandoffOptions; restore?: HandoffSelection } | null;
 function getPendingHandoffGlobal(): PendingHandoffGlobal {
 	return (globalThis as any)[HANDOFF_GLOBAL_KEY] ?? null;
 }
@@ -111,6 +118,25 @@ type HandoffOptions = {
 	mode?: string;
 	model?: string;
 };
+
+async function restoreHandoffSelection(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	restore: HandoffSelection,
+): Promise<void> {
+	const model = ctx.modelRegistry.find(restore.provider, restore.modelId);
+	if (!model) {
+		if (ctx.hasUI) {
+			ctx.ui.notify(`Handoff: could not restore ${restore.provider}/${restore.modelId}; using current session model`, "warning");
+		}
+	} else {
+		const ok = await pi.setModel(model);
+		if (!ok && ctx.hasUI) {
+			ctx.ui.notify(`Handoff: no API key for ${restore.provider}/${restore.modelId}; using current session model`, "warning");
+		}
+	}
+	pi.setThinkingLevel(restore.thinkingLevel);
+}
 
 /**
  * Apply -mode and -model options after a session switch.
@@ -230,10 +256,17 @@ async function performHandoff(
 		// Command path: full session replacement via ctx.newSession().
 		// After newSession(), the runtime tears down this session and creates a
 		// new one with fresh extensions. Our `pi` reference becomes stale, so we
-		// stash the prompt on globalThis for the new instance's session_start
-		// handler to pick up and send.
+		// stash the prompt plus any default model/thinking restore data on
+		// globalThis for the new instance's session_start handler.
 		const cmdCtx = ctx as ExtensionCommandContext;
-		setPendingHandoffGlobal({ prompt: finalPrompt, options });
+		const restore = !options?.mode && !options?.model && ctx.model
+			? {
+				provider: ctx.model.provider,
+				modelId: ctx.model.id,
+				thinkingLevel: pi.getThinkingLevel(),
+			}
+			: undefined;
+		setPendingHandoffGlobal({ prompt: finalPrompt, options, restore });
 		const newSessionResult = await cmdCtx.newSession({ parentSession: currentSessionFile });
 		if (newSessionResult.cancelled) {
 			setPendingHandoffGlobal(null);
@@ -372,11 +405,14 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (event, ctx) => {
 		handoffTimestamp = null;
 
-		// Pick up command-path handoff prompt stashed by the old extension instance
+		// Pick up command-path handoff data stashed by the old extension instance
 		if (event.reason === "new") {
 			const pending = getPendingHandoffGlobal();
 			if (pending) {
 				setPendingHandoffGlobal(null);
+				if (pending.restore) {
+					await restoreHandoffSelection(pi, ctx, pending.restore);
+				}
 				await applyHandoffOptions(pi, ctx, pending.options);
 				pi.sendUserMessage(pending.prompt);
 			}


### PR DESCRIPTION
Hi, I made this change so the model and thinking level are maintained during handoff in case the user manually changes them in another pi instance currently running. 

I used GPT-5.4 ( xhigh ) during exploration and implementation. 
I mostly used this ( code under ) so far but I was thinking this might be useful to have in pi-amplike for people who run multiple pi instances at the same time. 
```js
import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";

// Minimal companion shim for pi-amplike's command-path /handoff.
// It piggybacks on amplike's internal pending symbol instead of replacing /handoff.

type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;

type HandoffOptions = {
	mode?: string;
	model?: string;
};

type PendingAmplikeHandoff = {
	prompt: string;
	options?: HandoffOptions;
} | null;

type PendingAmplikeRestore = {
	provider: string;
	modelId: string;
	thinkingLevel: ThinkingLevel;
} | null;

const AMPLIKE_HANDOFF_PENDING_KEY = Symbol.for("pi-amplike-handoff-pending");
const AMPLIKE_HANDOFF_RESTORE_KEY = Symbol.for("pi-config-amplike-handoff-restore");

function getPendingAmplikeHandoff(): PendingAmplikeHandoff {
	return (globalThis as Record<symbol, PendingAmplikeHandoff | undefined>)[AMPLIKE_HANDOFF_PENDING_KEY] ?? null;
}

function getPendingAmplikeRestore(): PendingAmplikeRestore {
	return (globalThis as Record<symbol, PendingAmplikeRestore | undefined>)[AMPLIKE_HANDOFF_RESTORE_KEY] ?? null;
}

function setPendingAmplikeRestore(data: PendingAmplikeRestore) {
	if (data) {
		(globalThis as Record<symbol, PendingAmplikeRestore | undefined>)[AMPLIKE_HANDOFF_RESTORE_KEY] = data;
	} else {
		delete (globalThis as Record<symbol, PendingAmplikeRestore | undefined>)[AMPLIKE_HANDOFF_RESTORE_KEY];
	}
}

async function restoreModelAndThinking(
	pi: ExtensionAPI,
	ctx: ExtensionContext,
	pending: Exclude<PendingAmplikeRestore, null>,
) {
	const model = ctx.modelRegistry.find(pending.provider, pending.modelId);
	if (!model) {
		if (ctx.hasUI) {
			ctx.ui.notify(
				`Amplike handoff shim: could not restore ${pending.provider}/${pending.modelId}; using current session model`,
				"warning",
			);
		}
	} else {
		const ok = await pi.setModel(model);
		if (!ok && ctx.hasUI) {
			ctx.ui.notify(
				`Amplike handoff shim: no API key for ${pending.provider}/${pending.modelId}; using current session model`,
				"warning",
			);
		}
	}
	pi.setThinkingLevel(pending.thinkingLevel);
}

export default function (pi: ExtensionAPI) {
	let pendingRestore: PendingAmplikeRestore = null;

	pi.on("session_before_switch", async (event, ctx) => {
		if (event.reason !== "new" || !ctx.model) return;

		const pending = getPendingAmplikeHandoff();
		if (!pending) return;
		if (pending.options?.mode || pending.options?.model) return;

		setPendingAmplikeRestore({
			provider: ctx.model.provider,
			modelId: ctx.model.id,
			thinkingLevel: pi.getThinkingLevel(),
		});
	});

	pi.on("session_start", async (event) => {
		pendingRestore = null;
		if (event.reason !== "new") return;

		pendingRestore = getPendingAmplikeRestore();
		setPendingAmplikeRestore(null);
	});

	pi.on("before_agent_start", async (_event, ctx) => {
		if (!pendingRestore) return;

		const restore = pendingRestore;
		pendingRestore = null;
		await restoreModelAndThinking(pi, ctx, restore);
	});
}
```