### PR TITLE
handoff: defer command-path prompt to next macrotask so UI rebinds first

### DIFF
--- a/extensions/handoff.ts
+++ b/extensions/handoff.ts
@@ -402,21 +402,28 @@ export default function (pi: ExtensionAPI) {
 	// Also handles the command-path handoff: after cmdCtx.newSession() replaces
 	// the runtime, this NEW extension instance's session_start fires. We check
 	// globalThis for a pending prompt and send it.
-	pi.on("session_start", async (event, ctx) => {
+	pi.on("session_start", (event, ctx) => {
 		handoffTimestamp = null;
 
 		// Pick up command-path handoff data stashed by the old extension instance
-		if (event.reason === "new") {
-			const pending = getPendingHandoffGlobal();
-			if (pending) {
-				setPendingHandoffGlobal(null);
-				if (pending.restore) {
-					await restoreHandoffSelection(pi, ctx, pending.restore);
-				}
-				await applyHandoffOptions(pi, ctx, pending.options);
-				pi.sendUserMessage(pending.prompt);
+		if (event.reason !== "new") return;
+
+		const pending = getPendingHandoffGlobal();
+		if (!pending) return;
+
+		setPendingHandoffGlobal(null);
+
+		// Defer to a macrotask so the interactive mode can finish rebinding the
+		// replacement session and subscribe to its agent events before the handoff
+		// prompt starts a new turn. Without this, agent_start can fire before the
+		// UI subscribes, so the loading/working indicator is not shown after /handoff.
+		setTimeout(async () => {
+			if (pending.restore) {
+				await restoreHandoffSelection(pi, ctx, pending.restore);
 			}
-		}
+			await applyHandoffOptions(pi, ctx, pending.options);
+			pi.sendUserMessage(pending.prompt);
+		}, 0);
 	});
 
 	// /handoff command


### PR DESCRIPTION
Fixes #6.

## Summary

Fixes a race in command-path `/handoff` where the generated prompt could start running in the replacement session before interactive mode had subscribed to the new agent's events. When that happened, the UI missed `agent_start` and did not show the loading/working indicator.

The fix defers the `session_start` handoff activation to the next macrotask with `setTimeout(..., 0)`, matching the existing tool-path handoff pattern used after `agent_end`.

## Details

In pi interactive mode, the UI subscribes to the replacement session's agent events after extension binding completes. Since extension binding emits `session_start`, calling `pi.sendUserMessage()` immediately from the `session_start` handler can emit `agent_start` before the UI subscription exists.

This PR moves the restore/options/apply/send work into a macrotask so the rebind can finish first.

## Testing

Manually tested in interactive mode:

1. Started pi with pi-amplike enabled.
2. Ran `/handoff <goal>` from an existing conversation.
3. Confirmed the loading/working indicator appears while the handoff prompt is being processed.

No automated test suite was present in this checkout.